### PR TITLE
Add ircrb and require 'bored' to make repl-ing quicker

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift File.expand_path("lib", __dir__)
+require "bored"


### PR DESCRIPTION
This is just something I added while I was working on my other branch. Including a `.irbrc` file that loads up `"bored"` makes it quicker to play with things in irb